### PR TITLE
Add a handful of bindings to enable Wayland clients

### DIFF
--- a/cl-xkb.asd
+++ b/cl-xkb.asd
@@ -4,8 +4,12 @@
   :description "Common Lisp wrapper for libxkb"
   :author "Malcolm Still"
   :license "BSD 3-Clause"
+
+  :homepage "https://github.com/malcolmstill/cl-xkb"
+  :source-control (:git "https://github.com/malcolmstill/cl-xkb.git")
+  :bug-tracker "https://github.com/malcolmstill/cl-xkb/issues"
+
   :depends-on (#:cffi)
   :serial t
   :components ((:file "package")
                (:file "cl-xkb")))
-

--- a/cl-xkb.lisp
+++ b/cl-xkb.lisp
@@ -17,10 +17,19 @@
 (defcfun "xkb_context_new" :pointer
   (flags :uint32))
 
+(defcfun "xkb_context_unref" :void
+  (context :pointer))
+
+(defcfun "xkb_keymap_new_from_string" :pointer
+  (context :pointer)
+  (string :string)
+  (format :int)
+  (flags :int))
+
 (defcfun "xkb_keymap_new_from_names" :pointer
   (context :pointer)
   (names :pointer)
-  (flags :uint32))
+  (flags :int))
 
 ;;(defcfun "xkb_keymap_get_as_string" :string
  ;; (keymap :pointer)
@@ -58,10 +67,16 @@
   (state :pointer)
   (keycode :uint32))
 
+(defcfun "xkb_state_key_get_utf8" :int
+  (state :pointer)
+  (key :uint32)
+  (buffer :string)
+  (size :size))
+
 (defcfun "xkb_keysym_get_name" :int
   (keysym :uint32)
   (buffer :string)
-  (size :uint32))
+  (size :size))
 
 (defun get-keysym-name (keysym)
   (let* ((keysym-name (foreign-alloc :char :count 64)))
@@ -107,10 +122,22 @@
 (defcfun "xkb_keymap_max_keycode" :uint32
   (keymap :pointer))
 
-(defcfun "xkb_state_update_key" :int
+(defcfun "xkb_keymap_unref" :void
+  (keymap :pointer))
+
+(defcfun "xkb_state_update_key" :uint32
   (state :pointer)
   (key :uint32)
   (direction :int))
+
+(defcfun "xkb_state_update_mask" :int
+  (state :pointer)
+  (depressed-mods :uint32)
+  (latched-mods :uint32)
+  (locked-mods :uint32)
+  (depressed-layout :uint32)
+  (latched-layout :uint32)
+  (locked-layout :uint32))
 
 (defcfun "xkb_state_serialize_mods" :uint32
   (state :pointer)

--- a/package.lisp
+++ b/package.lisp
@@ -5,12 +5,15 @@
   (:export
    xkb-rule-names
    xkb-context-new
+   xkb-context-unref
+   xkb-keymap-new-from-string
    xkb-keymap-new-from-names
    xkb-keymap-get-as-string
    new-keymap-from-names
    xkb-state-new
+   xkb-state-key-get-utf8
    xkb-state-key-get-one-sym
-   ;;xkb-keysym-get-name
+   xkb-keysym-get-name
    get-keysym-name
    ;;xkb-keysym-from-name
    get-keysym-from-name
@@ -20,7 +23,9 @@
    xkb-keymap-key-by-name
    xkb-keymap-min-keycode
    xkb-keymap-max-keycode
+   xkb-keymap-unref
    xkb-state-update-key
+   xkb-state-update-mask
    xkb-state-serialize-mods
    xkb-state-serialize-layout
    xkb-state-unref
@@ -29,4 +34,3 @@
    toupper
    tolower
    ))
-   


### PR DESCRIPTION
This commit adds the following bindings:
- xkb_context_unref
- xkb_keymap_new_from_string
- xkb_state_key_get_utf8
- xkb_keymap_unref
- xkb_state_update_mask

And exports them out of the package. These new bindings enable keyboard management for Wayland clients.