### PR TITLE
Add bindings for Keysyms, Context, and Keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,19 @@
 
 ## Status
 
-`cl-xkb` is being developed primarily in support of [ulubis](https://github.com/malcolmstill/ulubis) and is therefor feature incomplete. Pull requests adding more of the API are more than welcome.
+`cl-xkb` started development to support [ulubis](https://github.com/malcolmstill/ulubis). The library currently supports these xkb [modules](https://xkbcommon.org/doc/current/modules.html):
 
-## Requiremnts
+- [Keysyms](https://xkbcommon.org/doc/current/group__keysyms.html)
+- [Library Context](https://xkbcommon.org/doc/current/group__context.html)
+- [Keymap Creation](https://xkbcommon.org/doc/current/group__keymap.html)
+- [Keymap Components](https://xkbcommon.org/doc/current/group__components.html)
+- [Keyboard State](https://xkbcommon.org/doc/current/group__state.html)
 
-`cl-xkb` requires libxkbcommon and cffi. It is likely that libxkbcommon already exists on your Linux installation if it is recent.
+Pull requests adding more of the API are more than welcome.
+
+## Requirements
+
+`cl-xkb` requires libxkbcommon and CFFI. It may require development files from your distribution -- the package should usually be called something like `libxkbcommon-dev`
 
 ## Installation
 

--- a/package.lisp
+++ b/package.lisp
@@ -1,36 +1,120 @@
 ;;;; package.lisp
 
 (defpackage :xkb
-  (:use :common-lisp :cffi)
+  (:use #:common-lisp #:cffi)
   (:export
-   xkb-rule-names
-   xkb-context-new
-   xkb-context-unref
-   xkb-keymap-new-from-string
-   xkb-keymap-new-from-names
-   xkb-keymap-get-as-string
-   new-keymap-from-names
-   xkb-state-new
-   xkb-state-key-get-utf8
-   xkb-state-key-get-one-sym
-   xkb-keysym-get-name
-   get-keysym-name
-   ;;xkb-keysym-from-name
-   get-keysym-from-name
-   ;;xkb-keysym-to-utf8
-   get-keysym-character
-   xkb-state-mod-name-is-active
-   xkb-keymap-key-by-name
-   xkb-keymap-min-keycode
-   xkb-keymap-max-keycode
-   xkb-keymap-unref
-   xkb-state-update-key
-   xkb-state-update-mask
-   xkb-state-serialize-mods
-   xkb-state-serialize-layout
-   xkb-state-unref
-   ;; Not XKB but they do deal with keysyms
-   ;; From ctypes.h
-   toupper
-   tolower
-   ))
+    #:xkb-rule-names
+    #:xkb-keycode
+    #:xkb-keysym
+    #:xkb-layout-index
+    #:xkb-layout-mask
+    #:xkb-level-index
+    #:xkb-mod-index
+    #:xkb-mod-mask
+    #:xkb-led-index
+    #:xkb-led-mask
+
+    #:+xkb-keycode-invalid+
+    #:+xkb-layout-invalid+
+    #:+xkb-level-invalid+
+    #:+xkb-mod-invalid+
+    #:+xkb-led-invalid+
+    #:+xkb-keycode-max+
+    #:xkb-keycode-is-legal-ext-p
+    #:xkb-keycode-is-legal-x11-p
+
+    ;; Keysyms
+    #:xkb-keysym-flags
+
+    #:xkb-keysym-get-name
+    #:get-keysym-name
+    #:xkb-keysym-from-name
+    #:get-keysym-from-name
+    #:xkb-keysym-to-utf8
+    #:get-keysym-character
+    #:xkb-keysym-to-utf32
+    #:xkb-utf32-to-keysym
+    #:xkb-keysym-to-upper
+    #:xkb-keysym-to-lower
+
+    ;; Library Context
+    #:xkb-context-flags
+    #:xkb-context-new
+    #:xkb-context-ref
+    #:xkb-context-unref
+    #:xkb-context-set-user-date
+    #:xkb-context-get-user-date
+
+    ;; Keymap Creation
+    #:xkb-keymap-compile-flags
+    #:xkb-keymap-format
+    #:+xkb-keymap-use-original-format+
+
+    #:xkb-keymap-new-from-names
+    #:new-keymap-from-names
+    #:xkb-keymap-new-from-file
+    #:xkb-keymap-new-from-string
+    #:xkb-keymap-new-from-buffer
+    #:xkb-keymap-ref
+    #:xkb-keymap-unref
+    #:xkb-keymap-get-as-string
+
+    ;; Keymap Components
+    #:xkb-keymap-min-keycode
+    #:xkb-keymap-max-keycode
+    #:xkb-keymap-key-for-each
+    #:xkb-keymap-key-get-name
+    #:xkb-keymap-key-by-name
+    #:xkb-keymap-num-mods
+    #:xkb-keymap-mod-get-name
+    #:xkb-keymap-mod-get-index
+    #:xkb-keymap-num-layouts
+    #:xkb-keymap-layout-get-name
+    #:xkb-keymap-layout-get-index
+    #:xkb-keymap-num-leds
+    #:xkb-keymap-led-get-name
+    #:xkb-keymap-led-get-index
+    #:xkb-keymap-num-levels-for-key
+    #:xkb-keymap-key-get-mods-for-level
+    #:xkb-keymap-key-get-syms-by-level
+    #:xkb-keymap-key-repeats
+
+    ;; Keyboard State
+    #:xkb-key-direction
+    #:xkb-state-component
+    #:xkb-state-match
+    #:xkb-consumed-mode
+
+    #:xkb-state-new
+    #:xkb-state-ref
+    #:xkb-state-unref
+    #:xkb-state-get-keymap
+    #:xkb-state-update-key
+    #:xkb-state-update-mask
+    #:xkb-state-key-get-syms
+    #:xkb-state-key-get-utf8
+    #:xkb-state-key-get-utf32
+    #:xkb-state-key-get-one-sym
+    #:xkb-state-key-get-layout
+    #:xkb-state-key-get-level
+    #:xkb-state-serialize-mods
+    #:xkb-state-serialize-layout
+    #:xkb-state-mod-name-is-active
+    #:xkb-state-mod-names-are-active
+    #:xkb-state-mod-index-is-active
+    #:xkb-state-mod-indices-are-active
+    #:xkb-state-key-get-consumed-mods2
+    #:xkb-state-key-get-consumed-mods
+    #:xkb-state-mod-index-is-consumed2
+    #:xkb-state-mod-index-is-consumed
+    #:xkb-state-mod-mask-remove-consumed
+    #:xkb-state-layout-name-is-active
+    #:xkb-state-layout-index-is-active
+    #:xkb-state-led-name-is-active
+    #:xkb-state-led-index-is-active
+
+    ;; Not XKB but they do deal with keysyms
+    ;; From ctypes.h
+    #:toupper
+    #:tolower
+    ))


### PR DESCRIPTION
This change adds all data types and functions from these libxkbcommon modules on <https://xkbcommon.org/doc/current/modules.html>:

- Keysyms
- Libary Context
- Keymap Creation
- Keymap Components

And leaves stubs for the modules Library Context, Include Paths, and Compose and dead-keys support for more advanced input processing.

This change also revises some of the higher-level wrappers around the bindings, specifically involving keysym functions writing to a string as ouptut, and #'new-keymap-from-names -- keeping the code idiomatic for CFFI, and reducing related memory leaks.