### PR TITLE
Allow :unix to use LD_LIBRARY_PATH override

### DIFF
--- a/cl-xkb.lisp
+++ b/cl-xkb.lisp
@@ -2,7 +2,7 @@
 (in-package :xkb)
 
 (define-foreign-library xkb
-  (:unix (:or "/usr/lib64/libxkbcommon.so.0" "/usr/lib64/libxkbcommon.so" "/usr/lib/x86_64-linux-gnu/libxkbcommon.so"))
+  (:unix (:or "/usr/lib64/libxkbcommon.so.0" "/usr/lib64/libxkbcommon.so" "/usr/lib/x86_64-linux-gnu/libxkbcommon.so" (:default "libxkbcommon")))
   (t (:default "libxkbcommon")))
 
 (use-foreign-library xkb)


### PR DESCRIPTION
Add a :default to the :unix spec for the foreign-library definition so that LD_LIBRARY_PATH environment variable can be used to override the system default.

This is untested on distros that have the existing hard-coded paths, but I don't think it would cause breakage.